### PR TITLE
Fixed background color for increase readability

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -145,7 +145,7 @@ class _FlutterLayoutArticleState extends State<FlutterLayoutArticle> {
                               )),
                         ),
                         height: 273,
-                        color: Colors.grey),
+                        color: Colors.grey[200]),
                   ],
                 ),
               ),


### PR DESCRIPTION
Changed background color from Colors.grey to Colors.grey[200] for improved readability.

This PR will fix this issue: #1 