### PR TITLE
Remove unnecessary state

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -67,7 +67,6 @@ class FlutterLayoutArticle extends StatefulWidget {
 
 class _FlutterLayoutArticleState extends State<FlutterLayoutArticle> {
   late int count;
-  late Widget example;
   late String code;
   late String explanation;
 

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -918,13 +918,15 @@ class Example28 extends Example {
 //////////////////////////////////////////////////
 
 class Example29 extends Example {
-  final String code = "Scaffold(\n"
-      "   body: Container(color: blue,\n"
-      "   child: SizedBox.expand(\n"
-      "      child: Column(\n"
-      "         children: [\n"
-      "            Text('Hello!'),\n"
-      "            Text('Goodbye!')]))))";
+  @override
+  final code = 'Scaffold(\n'
+      '   body: SizedBox.expand(,\n'
+      '     child: Conatiner(\n'
+      '       color: blue,\n'
+      '       child: Column(\n'
+      '         children: [\n'
+      '            Text(\'Hello!\'),\n'
+      '            Text(\'Goodbye!\')]))))';
 
   final String explanation =
       "If we want the Scaffold's child to be exactly the same size as the Scaffold itself, "


### PR DESCRIPTION
- removed uncessary state `example` from `_FlutterLayoutArticleState`
- fixed wrong code shown in screen in example 29